### PR TITLE
Adding "TE" parameter in subghz tx to fix it

### DIFF
--- a/lib/subghz.py
+++ b/lib/subghz.py
@@ -3,7 +3,7 @@ class Subghz:
     def __init__(self, serial_wrapper) -> None:
         self._serial_wrapper = serial_wrapper
         
-    def tx(self, hex_key: str, frequency: int = 433920000, te: int: 403, count: int = 10):
+    def tx(self, hex_key: str, frequency: int = 433920000, te: int = 403, count: int = 10):
         # TODO: params assertion and check if default frequency is allowed worldwide
         return self._serial_wrapper.send(f"subghz tx {hex_key} {frequency} {te} {count}")
 

--- a/lib/subghz.py
+++ b/lib/subghz.py
@@ -3,9 +3,9 @@ class Subghz:
     def __init__(self, serial_wrapper) -> None:
         self._serial_wrapper = serial_wrapper
         
-    def tx(self, hex_key: str, frequency: int = 433920000, count: int = 10):
+    def tx(self, hex_key: str, frequency: int = 433920000, te: int: 403, count: int = 10):
         # TODO: params assertion and check if default frequency is allowed worldwide
-        return self._serial_wrapper.send(f"subghz tx {hex_key} {frequency} {count}")
+        return self._serial_wrapper.send(f"subghz tx {hex_key} {frequency} {te} {count}")
 
     def decode_raw(self, sub_file: str) -> str:
         # TODO: implement regex catch errors


### PR DESCRIPTION
I was trying send some tx using:
~~~
flipper.subghz.tx(hex_key="DEADBEEF", frequency=433920000, count=5)
~~~
But I always got this error:
~~~
sscanf returned 3, key: deadbeef, frequency: 433920000, te:5, repeat: 10
subghz tx: illegal option -- DEADBEEF 433920000 5
usage: subghz tx <3 Byte Key: in hex> <Frequency: in Hz> <Te us> <Repeat count>
~~~

Then I was checking the code and just we need adding TE parameter. Default is 403 in CLI, so I used the same.

Now I can send tx without problems.

*Note: I using serial connection:

~~~~
flipper = PyFlipper(com="/dev/tty.usbmodemflip_NAME")
~~~~
