### PR TITLE
Support connections over plain tcp

### DIFF
--- a/src/pyflipper/lib/serial_wrapper.py
+++ b/src/pyflipper/lib/serial_wrapper.py
@@ -59,24 +59,23 @@ class TcpSerial:
         port = int(port)
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.connect((host, port))
-        buff = ''
-        while True:
-            buff += self._socket.recv(1024).decode()
-            if '>:' in buff:
-                break
+        self._read_response()
 
     @error_handler
     def send(self, payload: str) -> str:
         self._socket.sendall(f"{payload}\r".encode())
-        buff = ''
-        while True:
-            buff += self._socket.recv(1024).decode()
-            if '>:' in buff:
-                break
-        return '\n'.join(buff.splitlines()[1:-2])
+        return self._read_response()
 
     def write(self, msg):
         self._socket.sendall(msg)
 
     def ctrl_c(self):
         self._socket.sendall(b'\x03')
+
+    def _read_response(self):
+        buff = ''
+        while True:
+            buff += self._socket.recv(1024).decode()
+            if '>:' in buff:
+                break
+        return '\n'.join(buff.splitlines()[1:-2])

--- a/src/pyflipper/pyflipper.py
+++ b/src/pyflipper/pyflipper.py
@@ -28,7 +28,7 @@ class PyFlipper:
 
     def __init__(self, **kwargs) -> None:
         assert sum(bool(kwargs.get(k)) for k in ('com', 'ws', 'tcp')) == 1, \
-            'Only one of com, ws, port should be specified'
+            'Only one of com, ws, tcp should be specified'
         if kwargs.get('com'):
             self._serial_wrapper = LocalSerial(com=kwargs['com'])
         elif kwargs.get('ws'):

--- a/src/pyflipper/pyflipper.py
+++ b/src/pyflipper/pyflipper.py
@@ -14,7 +14,7 @@ from .lib.nfc import NFC
 from .lib.onewire import Onewire
 from .lib.ps import Ps
 from .lib.rfid import RFID
-from .lib.serial_wrapper import LocalSerial, WSSerial
+from .lib.serial_wrapper import LocalSerial, WSSerial, TcpSerial
 from .lib.storage import Storage
 from .lib.subghz import Subghz
 from .lib.vibro import Vibro
@@ -27,11 +27,14 @@ from .lib.update import Update
 class PyFlipper:
 
     def __init__(self, **kwargs) -> None:
-        assert bool(kwargs.get('com')) ^ bool(kwargs.get('ws')), "COM or Websocket required"
+        assert sum(bool(kwargs.get(k)) for k in ('com', 'ws', 'tcp')) == 1, \
+            'Only one of com, ws, port should be specified'
         if kwargs.get('com'):
-                self._serial_wrapper = LocalSerial(com=kwargs['com'])
+            self._serial_wrapper = LocalSerial(com=kwargs['com'])
+        elif kwargs.get('ws'):
+            self._serial_wrapper = WSSerial(ws=kwargs['ws']) 
         else:
-                self._serial_wrapper = WSSerial(ws=kwargs['ws']) 
+            self._serial_wrapper = TcpSerial(addr=kwargs['tcp']) 
         self.vibro = Vibro(serial_wrapper=self._serial_wrapper)
         self.date = Date(serial_wrapper=self._serial_wrapper)
         self.device_info = DeviceInfo(serial_wrapper=self._serial_wrapper)


### PR DESCRIPTION
Plain TCP serial connections are used in the wild, for example in Mikrotik routers. So if you connect your Flipper to a Mikrotik and configure a connection as:
```bash
/port remote-access add port=usb1 protocol=raw tcp-port=22170
```

You can use pyFlipper to access it with:
```python
from pyflipper.pyflipper import PyFlipper
flipper = PyFlipper(tcp='192.168.89.222:22170')
flipper.ps.list()
```