### PR TITLE
Fix ir limitations for NEC protocol

### DIFF
--- a/src/pyflipper/lib/ir.py
+++ b/src/pyflipper/lib/ir.py
@@ -13,8 +13,6 @@ class Ir(Threaded):
         assert protocol in self.PROTOCOLS, f"Available protocols: {self.PROTOCOLS}"
         assert is_hexstring(hex_address), "hex_address must be hexstring"
         assert is_hexstring(hex_command), "hex_command must be hexstring"
-        assert len(hex_address.replace(' ', '')) == 8 and len(hex_command.replace(
-            ' ', '')) == 8, "hex_address and hex_command must be 4 bytes long each"
         address = ' '.join(hex_address[i:i+2] for i in range(0, len(hex_address), 2)) if " " not in hex_address else hex_address
         command = ' '.join(hex_command[i:i+2] for i in range(0, len(hex_command), 2)) if " " not in hex_command else hex_command
         self._serial_wrapper.send(f"ir tx {protocol} {address} {command}")


### PR DESCRIPTION
The current implementation of IR does not work with the NEC protocol at least. It limits the address and command to be 4 bytes long, which is not true for the NEC protocol:
```bash

              _.-------.._                    -,
          .-"```"--..,,_/ /`-,               -,  \
       .:"          /:/  /'\  \     ,_...,  `. |  |
      /       ,----/:/  /`\ _\~`_-"`     _;
     '      / /`"""'\ \ \.~`_-'      ,-"'/
    |      | |  0    | | .-'      ,/`  /
   |    ,..\ \     ,.-"`       ,/`    /
  ;    :    `/`""\`           ,/--==,/-----,
  |    `-...|        -.___-Z:_______J...---;
  :         `                           _-'
 _L_  _     ___  ___  ___  ___  ____--"`___  _     ___
| __|| |   |_ _|| _ \| _ \| __|| _ \   / __|| |   |_ _|
| _| | |__  | | |  _/|  _/| _| |   /  | (__ | |__  | |
|_|  |____||___||_|  |_|  |___||_|_\   \___||____||___|

Welcome to Flipper Zero Command Line Interface!
Read Manual https://docs.flipperzero.one

Firmware version: 0.89.0 0.89.0 (5a58004b built on 16-08-2023)

>: ir rx
ir rx
Receiving  INFRARED...
Press Ctrl+C to abort
NEC, A:0x32, C:0x2E
NEC, A:0x32, C:0x2E R
```