### PR TITLE
fix: non-first connection

### DIFF
--- a/src/pyflipper/lib/serial_wrapper.py
+++ b/src/pyflipper/lib/serial_wrapper.py
@@ -19,6 +19,7 @@ class LocalSerial:
     def __init__(self, com) -> None:
         self._serial_port = serial.Serial(port=com, baudrate=9600,
                                          bytesize=8, timeout=None, stopbits=serial.STOPBITS_ONE)
+        self._serial_port.write(f"\n\n\r".encode())
         self._serial_port.read_until(b'>:') #skip welcome banner
 
     @error_handler


### PR DESCRIPTION
for some reason, if we connect again to the flipper and it's not the
first connection, the flipper would not send anything to us until we
sent something, thus we just send some \n s
